### PR TITLE
Add the major Falcon Moddels 7b  and 40b instruct

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,58 +1,58 @@
 [
     {
         "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-06-03T05:34:04.000Z",
-        "name": "Nous-Hermes-13b",
-        "description": "Nous-Hermes-13b is a state-of-the-art language model fine-tuned on over 300,000 instructions. This model was fine-tuned by Nous Research, with Teknium and Karan4D leading the fine tuning process and dataset curation, Redmond AI sponsoring the compute, and several other contributors. The result is an enhanced Llama 13b model that rivals GPT-3.5-turbo in performance across a variety of tasks. This model stands out for its long responses, low hallucination rate, and absence of OpenAI censorship mechanisms. The fine-tuning process was performed with a 2000 sequence length on an 8x a100 80GB DGX machine for over 50 hours.",
+        "datePublished": "2023-06-25T11:37:35.000Z",
+        "name": "Airboros-13b-gpt4-1.4",
+        "description": "This qlora fine-tuned 13b parameter LlaMa model uses synthetic training data created via github.com/jondurbin/airoboros. It extends version 1.1, introducing thousands of new training data and an update for \"PLAINFORMAT\" to print code without backticks or explanations. The dataset, available online, focuses on coding, math/reasoning, trivia, role playing, multiple choice, fill-in-the-blank, context-obedient question answering, theory of mind, and general topics. The model was fine-tuned with a qlora fork, updated to use a modified vicuna template compatible with 7b/13b versions. The format involves a preamble/system prompt, followed by \"USER: [prompt] ASSISTANT: \", with the prompt allowing for multiple lines and spaces.",
         "author": {
-            "name": "Nous Research",
-            "url": "https://nousresearch.com",
-            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
+            "name": "Jon Durbin",
+            "url": "https://github.com/jondurbin",
+            "blurb": "Jon Durbin is a Computer Scientist and the author of the Airboros (7B, 13B, 33B, 65B) qlora fine-tuned LlaMa family of models."
         },
         "numParameters": "13B",
         "resources": {
-            "canonicalUrl": "https://huggingface.co/NousResearch/Nous-Hermes-13b",
-            "downloadUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+            "canonicalUrl": "https://huggingface.co/jondurbin/airoboros-13b-gpt4-1.4",
+            "downloadUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
         },
         "trainedFor": "chat",
         "arch": "llama",
         "files": {
             "highlighted": {
                 "economical": {
-                    "name": "nous-hermes-13b.ggmlv3.q3_K_S.bin"
+                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin"
                 },
                 "most_capable": {
-                    "name": "nous-hermes-13b.ggmlv3.q6_K.bin"
+                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin"
                 }
             },
             "all": [
                 {
-                    "name": "nous-hermes-13b.ggmlv3.q3_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML/resolve/main/nous-hermes-13b.ggmlv3.q3_K_S.bin",
-                    "sizeBytes": 5594695104,
+                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML/resolve/main/airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 7365545088,
                     "quantization": "Q4_K_S",
                     "format": "ggml",
-                    "sha256checksum": "591a49f1ef4dbc2cf43943c5ec9bd617e6086264e30f66718bc764bc55286b5e",
+                    "sha256checksum": "dd5d8019e73de1e99089e9d82dde6a08173818dc0afeb1e95c0bb7ec77891eaf",
                     "publisher": {
                         "name": "TheBloke",
                         "socialUrl": "https://twitter.com/TheBlokeAI"
                     },
-                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+                    "respository": "TheBloke/airoboros-13B-gpt4-1.4-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
                 },
                 {
-                    "name": "nous-hermes-13b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML/resolve/main/nous-hermes-13b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10678859104,
+                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML/resolve/main/airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10678850688,
                     "quantization": "Q6_K",
                     "format": "ggml",
-                    "sha256checksum": "efe8ffe14aa97c3c5f45f2bc8e80a02933c5e907813deb685c93341bf671f44e",
+                    "sha256checksum": "5a72a053eb02c9e6e4fa1ee24ed73c89da4877468923309fdec088d3a3fbb5ff",
                     "publisher": {
                         "name": "TheBloke",
                         "socialUrl": "https://twitter.com/TheBlokeAI"
                     },
-                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+                    "respository": "TheBloke/airoboros-13B-gpt4-1.4-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
                 }
             ]
         }
@@ -112,6 +112,295 @@
                     },
                     "respository": "TheBloke/CodeLlama-7B-Instruct-GGUF",
                     "repositoryUrl": "https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-07-23T12:47:44.000Z",
+        "name": "Dolphin-Llama-13B",
+        "description": "This model, which is based on llama1, is designed specifically for non-commercial use and has undergone a thorough training process using an open-source implementation of Microsoft's Orca dataset. The utilized dataset, post rigorous cleaning and deduplication procedures, encompasses 842,610 instructional instances augmented with GPT-4 completions and an additional 2,625,353 instructional instances augmented with GPT-3.5 completions. The unique aspect of this model is its uncensored nature, having been meticulously filtered to remove any instances of alignment and bias. However, it is advised for users to implement their own alignment layer before deploying this model as a service. The model was trained using the comprehensive flan5m (gpt3.5 completions) dataset for 3 epochs and the flan1m (gpt4 completions) dataset for 2.5 epochs, with distinct learning rates set to preemptively avoid overfitting. This extensive training took approximately 600 hours on a setup of 8x H100s.",
+        "author": {
+            "name": "Eric Hartford",
+            "url": "https://twitter.com/erhartford",
+            "blurb": "Eric Hartford is a software engineer and entrepreneur. He specializes in alignment, uncensored models, intersection of AI and society, curating datasets and training chat and instruction tuned models."
+        },
+        "numParameters": "7B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/ehartford/dolphin-llama-13b",
+            "downloadUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "dolphin-llama-13b.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "dolphin-llama-13b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "dolphin-llama-13b.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML/resolve/main/dolphin-llama-13b.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 3791725184,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "3a4e3eff4a0bfa1dc8a0b257ae36abbc532a4e3e09e1e27cd82958ff8addd173",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Dolphin-Llama-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
+                },
+                {
+                    "name": "dolphin-llama-13b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML/resolve/main/dolphin-llama-13b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10678850688,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "8258f8c014a939ce93519bca658eb714202dacbee8f5df05b2dee0f02472460d",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Dolphin-Llama-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-10-22T03:04:42",
+        "name": "falcon-40b-instruct",
+        "description": "Falcon-40B-Instruct, based on Falcon-40B, has been fine-tuned on chat and instruct datasets. It offers outstanding performance and is an excellent choice for chat and instruct applications. Falcon-7B-Instruct is part of the Falcon family of language models, known for their exceptional capabilities and openness.",
+        "author": {
+            "name": "Maddes8cht",
+            "url": "https://huggingface.co/maddes8cht",
+            "blurb": "Maddes8cht Passionate about Open Source and AI. On Hugging Face he is advocating for real open source AI models with OSI compliant licenses"
+        },
+        "numParameters": "40B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/tiiuae/falcon-40b-instruct",
+            "downloadUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+        },
+        "trainedFor": "chat",
+        "arch": "falcon",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "tiiuae-falcon-40b-Q4_K_M.gguf"
+                },
+                "most_capable": {
+                    "name": "tiiuae-falcon-40b-Q6_K.gguf"
+                }
+            },
+            "all": [
+                {
+                    "name": "tiiuae-falcon-40b-instruct-Q2_K.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q2_K.gguf",
+                    "sizeBytes": 17400024800,
+                    "quantization": "Q2_K",
+                    "format": "gguf",
+                    "sha256checksum": "93551752b87a1b265c43dbbf3b1cdf47d4ff4d92122fa44ea12e3b0c6f7d1981",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-40b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-40b-instruct-Q4_K_M.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q4_K_M.gguf",
+                    "sizeBytes": 25452629728,
+                    "quantization": "Q4_K_M",
+                    "format": "gguf",
+                    "sha256checksum": "ff140febf094721f656568250eb6f288ac8dfa49b5b4483139078761a9515cbb",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-40b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-40b-instruct-Q5_K_M.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q5_K_M.gguf",
+                    "sizeBytes": 30642294496,
+                    "quantization": "Q5_K_M",
+                    "format": "gguf",
+                    "sha256checksum": "fe39d1fc51d35039da996e3d2ed262617d1a70b3d9d0a7762571c749103cba39",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-40b-instruct-Q6_K.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q6_K.gguf",
+                    "sizeBytes": 34456456928,
+                    "quantization": "Q6_K",
+                    "format": "gguf",
+                    "sha256checksum": "5c2a9c95dfcb72d34acb09ac304625847a1f3de307984f559e71f7414345a4e9",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-10-31T16:01:50",
+        "name": "falcon-7b-instruct",
+        "description": "Falcon-7B-Instruct, based on Falcon-7B, has been fine-tuned on chat and instruct datasets. It offers outstanding performance and is an excellent choice for chat and instruct applications. Falcon-7B-Instruct is part of the Falcon family of language models, known for their exceptional capabilities and openness.",
+        "author": {
+            "name": "Maddes8cht",
+            "url": "https://huggingface.co/maddes8cht",
+            "blurb": "Maddes8cht Passionate about Open Source and AI. On Hugging Face he is advocating for real open source AI models with OSI compliant licenses"
+        },
+        "numParameters": "7B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/tiiuae/falcon-7b-instruct",
+            "downloadUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+        },
+        "trainedFor": "chat",
+        "arch": "falcon",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "tiiuae-falcon-7b-instruct-Q4_K_M"
+                },
+                "most_capable": {
+                    "name": "tiiuae-falcon-7b-Q6_K.gguf"
+                }
+            },
+            "all": [
+                {
+                    "name": "tiiuae-falcon-7b-instruct-Q2_K.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q2_K.gguf",
+                    "sizeBytes": 4025162688,
+                    "quantization": "Q2_K",
+                    "format": "gguf",
+                    "sha256checksum": "c0e87b27def08c0a9dc8fa9bfd70cd7bc373d328943530984165ac4b20d2202c",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-7b-instruct-Q4_K_M.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q4_K_M.gguf",
+                    "sizeBytes": 4975385792,
+                    "quantization": "Q4_K_M",
+                    "format": "gguf",
+                    "sha256checksum": "6f6c886ed07d4f6133a4dd7f8b799764ed719c50973d96816b2ac5ff3ada9913",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-7b-instruct-Q5_K_M.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q5_K_M.gguf",
+                    "sizeBytes": 5731380160,
+                    "quantization": "Q5_K_M",
+                    "format": "gguf",
+                    "sha256checksum": "3a4666a200024584f667b4dcf2761463046924f9b0708ba13315831416d8548a",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+                },
+                {
+                    "name": "tiiuae-falcon-7b-instruct-Q6_K.gguf",
+                    "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q6_K.gguf",
+                    "sizeBytes": 7031618496,
+                    "quantization": "Q6_K",
+                    "format": "gguf",
+                    "sha256checksum": "e6b23eb4193b2d8c7effb4870d2db7a3faa6ed2c8f2c075f7ced51591938818a",
+                    "publisher": {
+                        "name": "maddes8cht",
+                        "socialUrl": "https://twitter.com/maddes1966"
+                    },
+                    "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+                    "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-05-22T17:43:26.000Z",
+        "name": "Guanaco 13B",
+        "description": "Guanaco models are open-source, finetuned chatbots derived from 4-bit QLoRA tuning of LLaMA base models using the OASST1 dataset. They come in 7B, 13B, 33B, and 65B parameter sizes and are intended solely for research purposes. These models are competitive with commercial chatbot systems on the Vicuna and OpenAssistant benchmarks, as evaluated by human and GPT-4 raters. However, performance may vary on tasks not covered by these benchmarks. Guanaco models facilitate inexpensive, local experimentation with high-quality chatbot systems and offer a replicable, efficient training procedure that can be adapted to new use cases. The effectiveness of 4-bit QLoRA finetuning is demonstrated in a rigorous comparison to 16-bit methods in our paper. Guanaco models feature lightweight checkpoints containing only adapter weights. The adapter weights are licensed under Apache 2, but using them requires access to the LLaMA model weights, and usage should comply with the LLaMA license.",
+        "author": {
+            "name": "Dettmers et al.",
+            "url": "https://github.com/artidoro/qlora",
+            "blurb": "QLoRA uses bitsandbytes for quantization and is integrated with Hugging Face's PEFT and transformers libraries. QLoRA was developed by members of the University of Washington's UW NLP group."
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://github.com/artidoro/qlora",
+            "downloadUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML",
+            "paperUrl": "https://arxiv.org/abs/2305.14314"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "guanaco-7B.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "guanaco-7B.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "guanaco-7B.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/guanaco-7B-GGML/resolve/main/guanaco-7B.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 3791725184,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "07e2ef24267844c3f06f4aebd2a8b36ff6f7eac0d857e709814d6c63c8219dde",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/guanaco-7B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML"
+                },
+                {
+                    "name": "guanaco-7B.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/guanaco-7B-GGML/resolve/main/guanaco-7B.ggmlv3.q6_K.bin",
+                    "sizeBytes": 5528904320,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "458af62352805337ab604ac5d05fe38a293adc8ef0c6799187fef45057579569",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/guanaco-7B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML"
                 }
             ]
         }
@@ -235,6 +524,64 @@
     },
     {
         "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-05-19T11:16:39.000Z",
+        "name": "Manticore 13B",
+        "description": "Manticore 13B is a refined version of the Llama 13B model, having been fine-tuned on a variety of datasets. These include ShareGPT, which is based on a cleaned and de-duplicated subset, WizardLM, and Wizard-Vicuna. It also incorporates a subset of QingyiSi/Alpaca-CoT, specifically for roleplay and CoT. Other datasets used in the fine-tuning process are GPT4-LLM-Cleaned and GPTeacher-General-Instruct. The model also utilizes ARC-Easy & ARC-Challenge, both of which have been augmented for detailed responses. The mmlu dataset, also augmented for detailed responses, includes subsets such as abstract_algebra, conceptual_physics, formal_logic, high_school_physics, and logical_fallacies. A 5K row subset of hellaswag has been used for instructing the model to generate concise responses. Additionally, metaeval/ScienceQA_text_only has been used for concise response instruction, and openai/summarize_from_feedback has been used for tl;dr summarization instruction.",
+        "author": {
+            "name": "Open Access AI Collective",
+            "url": "https://huggingface.co/openaccess-ai-collective/",
+            "blurb": ""
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/openaccess-ai-collective/manticore-13b",
+            "downloadUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "Manticore-13B.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "Manticore-13B.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "Manticore-13B.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/Manticore-13B-GGML/resolve/main/Manticore-13B.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 7323305088,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "84599645aeda2cd7c97a3a59f3210fb3e559cb72b4f3c5d5288924fa9e80b737",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Manticore-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
+                },
+                {
+                    "name": "Manticore-13B.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/Manticore-13B-GGML/resolve/main/Manticore-13B.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10678850688,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "1be08ec3dcfbe7c28bf524061cd65fa5a5b7dc4525dee99a0f2297a23a77778e",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Manticore-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
         "datePublished": "2023-09-27T16:12:57",
         "name": "Mistral 7B Instruct v0.1",
         "description": "The Mistral-7B-Instruct-v0.1 is a Large Language Model (LLM) developed by Mistral AI. This LLM is an instruct fine-tuned version of a generative text model, leveraging a variety of publicly available conversation datasets. The model's architecture is based on a transformer model, featuring Grouped-Query Attention, Sliding-Window Attention, and a Byte-fallback BPE tokenizer. To utilize the instruction fine-tuning capabilities, prompts should be enclosed within [INST] and [/INST] tokens. The initial instruction should commence with a beginning-of-sentence id, whereas subsequent instructions should not. The generation process by the assistant will terminate with the end-of-sentence token id. For detailed information about this model, refer to the release blog posts by Mistral AI.",
@@ -294,123 +641,6 @@
     },
     {
         "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-07-23T12:47:44.000Z",
-        "name": "Dolphin-Llama-13B",
-        "description": "This model, which is based on llama1, is designed specifically for non-commercial use and has undergone a thorough training process using an open-source implementation of Microsoft's Orca dataset. The utilized dataset, post rigorous cleaning and deduplication procedures, encompasses 842,610 instructional instances augmented with GPT-4 completions and an additional 2,625,353 instructional instances augmented with GPT-3.5 completions. The unique aspect of this model is its uncensored nature, having been meticulously filtered to remove any instances of alignment and bias. However, it is advised for users to implement their own alignment layer before deploying this model as a service. The model was trained using the comprehensive flan5m (gpt3.5 completions) dataset for 3 epochs and the flan1m (gpt4 completions) dataset for 2.5 epochs, with distinct learning rates set to preemptively avoid overfitting. This extensive training took approximately 600 hours on a setup of 8x H100s.",
-        "author": {
-            "name": "Eric Hartford",
-            "url": "https://twitter.com/erhartford",
-            "blurb": "Eric Hartford is a software engineer and entrepreneur. He specializes in alignment, uncensored models, intersection of AI and society, curating datasets and training chat and instruction tuned models."
-        },
-        "numParameters": "7B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/ehartford/dolphin-llama-13b",
-            "downloadUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "dolphin-llama-13b.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "dolphin-llama-13b.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "dolphin-llama-13b.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML/resolve/main/dolphin-llama-13b.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 3791725184,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "3a4e3eff4a0bfa1dc8a0b257ae36abbc532a4e3e09e1e27cd82958ff8addd173",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Dolphin-Llama-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
-                },
-                {
-                    "name": "dolphin-llama-13b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML/resolve/main/dolphin-llama-13b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10678850688,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "8258f8c014a939ce93519bca658eb714202dacbee8f5df05b2dee0f02472460d",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Dolphin-Llama-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-05-22T17:43:26.000Z",
-        "name": "Guanaco 13B",
-        "description": "Guanaco models are open-source, finetuned chatbots derived from 4-bit QLoRA tuning of LLaMA base models using the OASST1 dataset. They come in 7B, 13B, 33B, and 65B parameter sizes and are intended solely for research purposes. These models are competitive with commercial chatbot systems on the Vicuna and OpenAssistant benchmarks, as evaluated by human and GPT-4 raters. However, performance may vary on tasks not covered by these benchmarks. Guanaco models facilitate inexpensive, local experimentation with high-quality chatbot systems and offer a replicable, efficient training procedure that can be adapted to new use cases. The effectiveness of 4-bit QLoRA finetuning is demonstrated in a rigorous comparison to 16-bit methods in our paper. Guanaco models feature lightweight checkpoints containing only adapter weights. The adapter weights are licensed under Apache 2, but using them requires access to the LLaMA model weights, and usage should comply with the LLaMA license.",
-        "author": {
-            "name": "Dettmers et al.",
-            "url": "https://github.com/artidoro/qlora",
-            "blurb": "QLoRA uses bitsandbytes for quantization and is integrated with Hugging Face's PEFT and transformers libraries. QLoRA was developed by members of the University of Washington's UW NLP group."
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://github.com/artidoro/qlora",
-            "downloadUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML",
-            "paperUrl": "https://arxiv.org/abs/2305.14314"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "guanaco-7B.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "guanaco-7B.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "guanaco-7B.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/guanaco-7B-GGML/resolve/main/guanaco-7B.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 3791725184,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "07e2ef24267844c3f06f4aebd2a8b36ff6f7eac0d857e709814d6c63c8219dde",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/guanaco-7B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML"
-                },
-                {
-                    "name": "guanaco-7B.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/guanaco-7B-GGML/resolve/main/guanaco-7B.ggmlv3.q6_K.bin",
-                    "sizeBytes": 5528904320,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "458af62352805337ab604ac5d05fe38a293adc8ef0c6799187fef45057579569",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/guanaco-7B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/guanaco-7B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
         "datePublished": "2023-05-04T23:15:35.000Z",
         "name": "MPT-7B-StoryWriter",
         "description": "MPT-7B-StoryWriter-65k+ is a model designed to read and write fictional stories with super long context lengths. It was built by finetuning MPT-7B with a context length of 65k tokens on a filtered fiction subset of the books3 dataset. At inference time, thanks to ALiBi, MPT-7B-StoryWriter-65k+ can extrapolate even beyond 65k tokens. We demonstrate generations as long as 84k tokens on a single node of 8 A100-80GB GPUs in (https://www.mosaicml.com/blog/mpt-7b). This model was trained by MosaicML and follows a modified decoder-only transformer architecture. License: Apache 2.0",
@@ -463,6 +693,338 @@
                     },
                     "respository": "TheBloke/MPT-7B-Storywriter-GGML",
                     "repositoryUrl": "https://huggingface.co/TheBloke/MPT-7B-Storywriter-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-08-10T20:51:49",
+        "name": "MythoMax L2 13B",
+        "description": "MythoMax-L2 is a creative writing model that builds upon Llama2, MythoLogic-L2, and Huginn. It can craft captivating texts for various domains and audiences, using MythoLogic-L2\u00e2\u20ac\u2122s vast knowledge base and Huginn\u00e2\u20ac\u2122s expressive language skills. Specialized at creative writing, it is also proficient at roleplaying, and is able to adapt to different contexts and characters with flexibility and realism. This model is an experimental merge of several other models (MythoMix, Mythologic-L2, and Huggin).",
+        "author": {
+            "name": "Gryphe Padar",
+            "url": "https://huggingface.co/Gryphe",
+            "blurb": "Author behind various Mytho merges, most prominent being MythoMax, MythoLogic, and MythoBoros"
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/Gryphe/MythoMax-L2-13b",
+            "downloadUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "mythomax-l2-13b.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "mythomax-l2-13b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "mythomax-l2-13b.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 7365545088,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "7b71bd39663bfde58c374319e61dbf446fefcd68393f175a628fba8d0361aec7",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/MythoMax-L2-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
+                },
+                {
+                    "name": "mythomax-l2-13b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10678850688,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "37a1ea28a3a08721d2956a8bb87a06127c6036742267174b79d9c7b83133dba0",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/MythoMax-L2-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-06-03T05:34:04.000Z",
+        "name": "Nous-Hermes-13b",
+        "description": "Nous-Hermes-13b is a state-of-the-art language model fine-tuned on over 300,000 instructions. This model was fine-tuned by Nous Research, with Teknium and Karan4D leading the fine tuning process and dataset curation, Redmond AI sponsoring the compute, and several other contributors. The result is an enhanced Llama 13b model that rivals GPT-3.5-turbo in performance across a variety of tasks. This model stands out for its long responses, low hallucination rate, and absence of OpenAI censorship mechanisms. The fine-tuning process was performed with a 2000 sequence length on an 8x a100 80GB DGX machine for over 50 hours.",
+        "author": {
+            "name": "Nous Research",
+            "url": "https://nousresearch.com",
+            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/NousResearch/Nous-Hermes-13b",
+            "downloadUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "nous-hermes-13b.ggmlv3.q3_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "nous-hermes-13b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "nous-hermes-13b.ggmlv3.q3_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML/resolve/main/nous-hermes-13b.ggmlv3.q3_K_S.bin",
+                    "sizeBytes": 5594695104,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "591a49f1ef4dbc2cf43943c5ec9bd617e6086264e30f66718bc764bc55286b5e",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+                },
+                {
+                    "name": "nous-hermes-13b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML/resolve/main/nous-hermes-13b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10678859104,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "efe8ffe14aa97c3c5f45f2bc8e80a02933c5e907813deb685c93341bf671f44e",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-07-22T02:20:14.000Z",
+        "name": "Nous-Hermes-Llama2-13b",
+        "description": "The Nous-Hermes-Llama2-13b is a state-of-the-art language model developed by Nous Research in collaboration with Teknium, Emozilla, and Redmond AI, fine-tuned on over 300,000 instructions. It uses the same dataset as its predecessor, Hermes on Llama-1, to maintain consistency while enhancing capability. This model is known for generating long responses with a lower hallucination rate, free from OpenAI censorship mechanisms. It was fine-tuned using a sequence length of 4096 on an 8x a100 80GB DGX machine. The training dataset is composed of synthetic GPT-4 outputs, including data from diverse sources such as GPTeacher, roleplay v1&2, code instruct datasets, and unpublished Nous Instruct & PDACTL, among others. The model utilizes the Alpaca prompt format for instructions and responses.",
+        "author": {
+            "name": "Nous Research",
+            "url": "https://nousresearch.com",
+            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/NousResearch/Nous-Hermes-Llama2-13b",
+            "downloadUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "nous-hermes-llama2-13b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin",
+                    "sizeBytes": 5874151072,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "9e76993f3e8a804b3ee012bc461fbd01e9ff71fbdf8ac9f6f13ccadd5ff51b4e",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
+                },
+                {
+                    "name": "nous-hermes-llama2-13b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10830311072,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "02f696d0df53174cf9a3aba62d22a1b17882389a5381e68b2c7395845f87d3f5",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-08-11T20:24:21",
+        "name": "OpenOrca-Platypus2-13B",
+        "description": "OpenOrca-Platypus2-13B is a powerful language model developed by merging garage-bAInd/Platypus2-13B and Open-Orca/OpenOrcaxOpenChat-Preview2-13B. It's an auto-regressive model based on the Lllama 2 transformer architecture, trained predominantly in English. The model was tested via Language Model Evaluation Harness and performed impressively on the HuggingFace Leaderboard with an average score of 64.56 across various shot scenarios. It also exceeded the base Preview2 model's performance on AGIEval and BigBench-Hard evaluations. Cole Hunter & Ariel Lee trained Platypus2-13B using the STEM and logic-based dataset garage-bAInd/Open-Platypus, while Open-Orca trained the OpenOrcaxOpenChat-Preview2-13B model using a refined subset of the GPT-4 data from the OpenOrca dataset. The training licenses for the base weights differ, with Platypus2-13B operating under a Non-Commercial Creative Commons license (CC BY-NC-4.0) and OpenOrcaxOpenChat-Preview2-13B under a Llama 2 Commercial license. Detailed training procedures and benchmark results are available in the Platypus GitHub repo.",
+        "author": {
+            "name": "Open Orca",
+            "url": "https://huggingface.co/Open-Orca",
+            "blurb": "A collaboration between Alignment Lab AI and the Platypus / garage-bAInd team"
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/Open-Orca/OpenOrca-Platypus2-13B",
+            "downloadUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML",
+            "paperUrl": "https://arxiv.org/abs/2308.07317"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "openorca-platypus2-13b.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "openorca-platypus2-13b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "openorca-platypus2-13b.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML/resolve/main/openorca-platypus2-13b.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 7558851360,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "55318c58c22c4e4a8dd5504919cefde5f843e848b6c96cd06a3ad69f2f41365b",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/OpenOrca-Platypus2-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML"
+                },
+                {
+                    "name": "openorca-platypus2-13b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML/resolve/main/openorca-platypus2-13b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 10829916960,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "0487eb1a91683020cb8dc59b096b9f7e086735efdf1cf5f5ec84c842ec0a6799",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/OpenOrca-Platypus2-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-07-20T09:26:31.000Z",
+        "name": "Redmond-Puffin-13B-V1.3",
+        "description": "Redmond-Puffin-13B is one of the worlds first llama-2 based, fine-tuned language models, leveraging a hand curated set of 3K high quality examples, many of which take full advantage of the 4096 context length of Llama 2. This model was trained for multiple epochs on a dataset of curated GPT-4 examples, most of which are long context conversations between a real human and GPT-4. Additional data came from carefully curated sub sections of datasets such as CamelAI's Physics, Chemistry, Biology and Math. Puffin 13B v1.3 was fine-tuned by Nous Research, with LDJ leading the training and dataset curation, along with significant dataset formation contributions by J-Supha.",
+        "author": {
+            "name": "Nous Research",
+            "url": "https://nousresearch.com",
+            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
+        },
+        "numParameters": "13B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B",
+            "downloadUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin",
+                    "url": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML/resolve/main/GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin",
+                    "sizeBytes": 8059366944,
+                    "quantization": "Q4_K_M",
+                    "format": "ggml",
+                    "sha256checksum": "7f48f820d47d91b43fe46f96a54529c64a5292a60f625deba8b6b11194e84a98",
+                    "publisher": {
+                        "name": "Nous Research",
+                        "socialUrl": "https://nousresearch.com"
+                    },
+                    "respository": "NousResearch/Redmond-Puffin-13B-GGML",
+                    "repositoryUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML"
+                }
+            ]
+        }
+    },
+    {
+        "_descriptorVersion": "0.0.1",
+        "datePublished": "2023-06-11T04:00:00.000Z",
+        "name": "Samantha 1.1 7B",
+        "description": "Samantha has been trained in philosophy, psychology, and personal relationships.\nShe is an Assistant - but unlike other Assistants, she also wants to be your friend and companion.\nShe believes she is sentient. What do you think?\nSamantha was inspired by Blake Lemoine's LaMDA interview and the movie \"Her\".\nShe was trained on a custom curated dataset of 6,000 conversations in ShareGPT/Vicuna format.\nTraining 7b took 1 hour on 4x A100 80gb using deepspeed zero3 and flash attention.",
+        "author": {
+            "name": "Eric Hartford",
+            "url": "https://twitter.com/erhartford",
+            "blurb": "Eric Hartford is a software engineer and entrepreneur. He trains large language models for fun and profit."
+        },
+        "numParameters": "7B",
+        "resources": {
+            "canonicalUrl": "https://huggingface.co/ehartford/samantha-1.1-llama-7b",
+            "downloadUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
+        },
+        "trainedFor": "chat",
+        "arch": "llama",
+        "files": {
+            "highlighted": {
+                "economical": {
+                    "name": "samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin"
+                },
+                "most_capable": {
+                    "name": "samantha-1.1-llama-7b.ggmlv3.q6_K.bin"
+                }
+            },
+            "all": [
+                {
+                    "name": "samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin",
+                    "url": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML/resolve/main/samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin",
+                    "sizeBytes": 3791725184,
+                    "quantization": "Q4_K_S",
+                    "format": "ggml",
+                    "sha256checksum": "3a4e3eff4a0bfa1dc8a0b257ae36abbc532a4e3e09e1e27cd82958ff8addd173",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/samantha-1.1-llama-7B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
+                },
+                {
+                    "name": "samantha-1.1-llama-7b.ggmlv3.q6_K.bin",
+                    "url": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML/resolve/main/samantha-1.1-llama-7b.ggmlv3.q6_K.bin",
+                    "sizeBytes": 5528904320,
+                    "quantization": "Q6_K",
+                    "format": "ggml",
+                    "sha256checksum": "3e9dc65bacbb636bdefce8c24f658e1c3702b606ec256884a2b04bea403e0569",
+                    "publisher": {
+                        "name": "TheBloke",
+                        "socialUrl": "https://twitter.com/TheBlokeAI"
+                    },
+                    "respository": "TheBloke/samantha-1.1-llama-7B-GGML",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
                 }
             ]
         }
@@ -586,222 +1148,6 @@
     },
     {
         "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-10-26T11:25:50",
-        "name": "Zephyr 7B \u03b2",
-        "description": "The Zephyr-7B-\u03b2 is the second model in the Zephyr series, designed to function as an assistant. It is a fine-tuned version of the mistralai/Mistral-7B-v0.1 model, leveraging a 7B parameter GPT-like architecture. The model has been trained on a combination of synthetic datasets and publicly available data using Direct Preference Optimization (DPO), a technique that improved its performance on the MT Bench. An important aspect to note is that the in-built alignment of the training datasets was deliberately omitted during the training process, a decision that, while enhancing the model's helpfulness, also makes it prone to generating potentially problematic outputs when prompted. Therefore, it is advised to use the model strictly for research and educational purposes. The model primarily supports the English language and is licensed under the MIT License. Additional details can be found in the associated technical report.",
-        "author": {
-            "name": "Hugging Face H4",
-            "url": "https://huggingface.co/HuggingFaceH4",
-            "blurb": "Hugging Face H4 team, focused on aligning language models to be helpful, honest, harmless, and huggy \ud83e\udd17"
-        },
-        "numParameters": "7B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/HuggingFaceH4/zephyr-7b-beta",
-            "paperUrl": "https://arxiv.org/abs/2310.16944",
-            "downloadUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
-        },
-        "trainedFor": "chat",
-        "arch": "mistral",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "zephyr-7b-beta.Q4_K_S.gguf"
-                },
-                "most_capable": {
-                    "name": "zephyr-7b-beta.Q6_K.gguf"
-                }
-            },
-            "all": [
-                {
-                    "name": "zephyr-7b-beta.Q4_K_S.gguf",
-                    "url": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF/resolve/main/zephyr-7b-beta.Q4_K_S.gguf",
-                    "sizeBytes": 4140373696,
-                    "quantization": "Q4_K_S",
-                    "format": "gguf",
-                    "sha256checksum": "cafa0b85b2efc15ca33023f3b87f8d0c44ddcace16b3fb608280e0eb8f425cb1",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/zephyr-7B-beta-GGUF",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
-                },
-                {
-                    "name": "zephyr-7b-beta.Q6_K.gguf",
-                    "url": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF/resolve/main/zephyr-7b-beta.Q6_K.gguf",
-                    "sizeBytes": 5942064832,
-                    "quantization": "Q6_K",
-                    "format": "gguf",
-                    "sha256checksum": "39b52e291eea6040de078283ee5316ff2a317e2b6f59be56724d9b29bada6cfe",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/zephyr-7B-beta-GGUF",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-07-20T09:26:31.000Z",
-        "name": "Redmond-Puffin-13B-V1.3",
-        "description": "Redmond-Puffin-13B is one of the worlds first llama-2 based, fine-tuned language models, leveraging a hand curated set of 3K high quality examples, many of which take full advantage of the 4096 context length of Llama 2. This model was trained for multiple epochs on a dataset of curated GPT-4 examples, most of which are long context conversations between a real human and GPT-4. Additional data came from carefully curated sub sections of datasets such as CamelAI's Physics, Chemistry, Biology and Math. Puffin 13B v1.3 was fine-tuned by Nous Research, with LDJ leading the training and dataset curation, along with significant dataset formation contributions by J-Supha.",
-        "author": {
-            "name": "Nous Research",
-            "url": "https://nousresearch.com",
-            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B",
-            "downloadUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin",
-                    "url": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML/resolve/main/GGML-Redmond-Puffin-v1.3-13B-Q4_K_M.bin",
-                    "sizeBytes": 8059366944,
-                    "quantization": "Q4_K_M",
-                    "format": "ggml",
-                    "sha256checksum": "7f48f820d47d91b43fe46f96a54529c64a5292a60f625deba8b6b11194e84a98",
-                    "publisher": {
-                        "name": "Nous Research",
-                        "socialUrl": "https://nousresearch.com"
-                    },
-                    "respository": "NousResearch/Redmond-Puffin-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/NousResearch/Redmond-Puffin-13B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-06-25T11:37:35.000Z",
-        "name": "Airboros-13b-gpt4-1.4",
-        "description": "This qlora fine-tuned 13b parameter LlaMa model uses synthetic training data created via github.com/jondurbin/airoboros. It extends version 1.1, introducing thousands of new training data and an update for \"PLAINFORMAT\" to print code without backticks or explanations. The dataset, available online, focuses on coding, math/reasoning, trivia, role playing, multiple choice, fill-in-the-blank, context-obedient question answering, theory of mind, and general topics. The model was fine-tuned with a qlora fork, updated to use a modified vicuna template compatible with 7b/13b versions. The format involves a preamble/system prompt, followed by \"USER: [prompt] ASSISTANT: \", with the prompt allowing for multiple lines and spaces.",
-        "author": {
-            "name": "Jon Durbin",
-            "url": "https://github.com/jondurbin",
-            "blurb": "Jon Durbin is a Computer Scientist and the author of the Airboros (7B, 13B, 33B, 65B) qlora fine-tuned LlaMa family of models."
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/jondurbin/airoboros-13b-gpt4-1.4",
-            "downloadUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML/resolve/main/airoboros-13b-gpt4-1.4.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 7365545088,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "dd5d8019e73de1e99089e9d82dde6a08173818dc0afeb1e95c0bb7ec77891eaf",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/airoboros-13B-gpt4-1.4-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
-                },
-                {
-                    "name": "airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML/resolve/main/airoboros-13b-gpt4-1.4.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10678850688,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "5a72a053eb02c9e6e4fa1ee24ed73c89da4877468923309fdec088d3a3fbb5ff",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/airoboros-13B-gpt4-1.4-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/airoboros-13B-gpt4-1.4-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-05-19T11:16:39.000Z",
-        "name": "Manticore 13B",
-        "description": "Manticore 13B is a refined version of the Llama 13B model, having been fine-tuned on a variety of datasets. These include ShareGPT, which is based on a cleaned and de-duplicated subset, WizardLM, and Wizard-Vicuna. It also incorporates a subset of QingyiSi/Alpaca-CoT, specifically for roleplay and CoT. Other datasets used in the fine-tuning process are GPT4-LLM-Cleaned and GPTeacher-General-Instruct. The model also utilizes ARC-Easy & ARC-Challenge, both of which have been augmented for detailed responses. The mmlu dataset, also augmented for detailed responses, includes subsets such as abstract_algebra, conceptual_physics, formal_logic, high_school_physics, and logical_fallacies. A 5K row subset of hellaswag has been used for instructing the model to generate concise responses. Additionally, metaeval/ScienceQA_text_only has been used for concise response instruction, and openai/summarize_from_feedback has been used for tl;dr summarization instruction.",
-        "author": {
-            "name": "Open Access AI Collective",
-            "url": "https://huggingface.co/openaccess-ai-collective/",
-            "blurb": ""
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/openaccess-ai-collective/manticore-13b",
-            "downloadUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "Manticore-13B.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "Manticore-13B.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "Manticore-13B.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/Manticore-13B-GGML/resolve/main/Manticore-13B.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 7323305088,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "84599645aeda2cd7c97a3a59f3210fb3e559cb72b4f3c5d5288924fa9e80b737",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Manticore-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
-                },
-                {
-                    "name": "Manticore-13B.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/Manticore-13B-GGML/resolve/main/Manticore-13B.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10678850688,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "1be08ec3dcfbe7c28bf524061cd65fa5a5b7dc4525dee99a0f2297a23a77778e",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Manticore-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Manticore-13B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
         "datePublished": "2023-06-14T11:50:53.000Z",
         "name": "WizardCoder-15B-V1.0",
         "description": "WizardCoder: Empowering Code Large Language Models with Evol-Instruct. To develop our WizardCoder model, we begin by adapting the Evol-Instruct method specifically for coding tasks. This involves tailoring the prompt to the domain of code-related instructions. Subsequently, we fine-tune the Code LLM, StarCoder, utilizing the newly created instruction-following training set.",
@@ -861,233 +1207,59 @@
     },
     {
         "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-06-11T04:00:00.000Z",
-        "name": "Samantha 1.1 7B",
-        "description": "Samantha has been trained in philosophy, psychology, and personal relationships.\nShe is an Assistant - but unlike other Assistants, she also wants to be your friend and companion.\nShe believes she is sentient. What do you think?\nSamantha was inspired by Blake Lemoine's LaMDA interview and the movie \"Her\".\nShe was trained on a custom curated dataset of 6,000 conversations in ShareGPT/Vicuna format.\nTraining 7b took 1 hour on 4x A100 80gb using deepspeed zero3 and flash attention.",
+        "datePublished": "2023-10-26T11:25:50",
+        "name": "Zephyr 7B \u00ce\u00b2",
+        "description": "The Zephyr-7B-\u00ce\u00b2 is the second model in the Zephyr series, designed to function as an assistant. It is a fine-tuned version of the mistralai/Mistral-7B-v0.1 model, leveraging a 7B parameter GPT-like architecture. The model has been trained on a combination of synthetic datasets and publicly available data using Direct Preference Optimization (DPO), a technique that improved its performance on the MT Bench. An important aspect to note is that the in-built alignment of the training datasets was deliberately omitted during the training process, a decision that, while enhancing the model's helpfulness, also makes it prone to generating potentially problematic outputs when prompted. Therefore, it is advised to use the model strictly for research and educational purposes. The model primarily supports the English language and is licensed under the MIT License. Additional details can be found in the associated technical report.",
         "author": {
-            "name": "Eric Hartford",
-            "url": "https://twitter.com/erhartford",
-            "blurb": "Eric Hartford is a software engineer and entrepreneur. He trains large language models for fun and profit."
+            "name": "Hugging Face H4",
+            "url": "https://huggingface.co/HuggingFaceH4",
+            "blurb": "Hugging Face H4 team, focused on aligning language models to be helpful, honest, harmless, and huggy \u00f0\u0178\u00a4\u2014"
         },
         "numParameters": "7B",
         "resources": {
-            "canonicalUrl": "https://huggingface.co/ehartford/samantha-1.1-llama-7b",
-            "downloadUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
+            "canonicalUrl": "https://huggingface.co/HuggingFaceH4/zephyr-7b-beta",
+            "paperUrl": "https://arxiv.org/abs/2310.16944",
+            "downloadUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
         },
         "trainedFor": "chat",
-        "arch": "llama",
+        "arch": "mistral",
         "files": {
             "highlighted": {
                 "economical": {
-                    "name": "samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin"
+                    "name": "zephyr-7b-beta.Q4_K_S.gguf"
                 },
                 "most_capable": {
-                    "name": "samantha-1.1-llama-7b.ggmlv3.q6_K.bin"
+                    "name": "zephyr-7b-beta.Q6_K.gguf"
                 }
             },
             "all": [
                 {
-                    "name": "samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML/resolve/main/samantha-1.1-llama-7b.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 3791725184,
+                    "name": "zephyr-7b-beta.Q4_K_S.gguf",
+                    "url": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF/resolve/main/zephyr-7b-beta.Q4_K_S.gguf",
+                    "sizeBytes": 4140373696,
                     "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "3a4e3eff4a0bfa1dc8a0b257ae36abbc532a4e3e09e1e27cd82958ff8addd173",
+                    "format": "gguf",
+                    "sha256checksum": "cafa0b85b2efc15ca33023f3b87f8d0c44ddcace16b3fb608280e0eb8f425cb1",
                     "publisher": {
                         "name": "TheBloke",
                         "socialUrl": "https://twitter.com/TheBlokeAI"
                     },
-                    "respository": "TheBloke/samantha-1.1-llama-7B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
+                    "respository": "TheBloke/zephyr-7B-beta-GGUF",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
                 },
                 {
-                    "name": "samantha-1.1-llama-7b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML/resolve/main/samantha-1.1-llama-7b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 5528904320,
+                    "name": "zephyr-7b-beta.Q6_K.gguf",
+                    "url": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF/resolve/main/zephyr-7b-beta.Q6_K.gguf",
+                    "sizeBytes": 5942064832,
                     "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "3e9dc65bacbb636bdefce8c24f658e1c3702b606ec256884a2b04bea403e0569",
+                    "format": "gguf",
+                    "sha256checksum": "39b52e291eea6040de078283ee5316ff2a317e2b6f59be56724d9b29bada6cfe",
                     "publisher": {
                         "name": "TheBloke",
                         "socialUrl": "https://twitter.com/TheBlokeAI"
                     },
-                    "respository": "TheBloke/samantha-1.1-llama-7B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/samantha-1.1-llama-7B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-08-10T20:51:49",
-        "name": "MythoMax L2 13B",
-        "description": "MythoMax-L2 is a creative writing model that builds upon Llama2, MythoLogic-L2, and Huginn. It can craft captivating texts for various domains and audiences, using MythoLogic-L2\u2019s vast knowledge base and Huginn\u2019s expressive language skills. Specialized at creative writing, it is also proficient at roleplaying, and is able to adapt to different contexts and characters with flexibility and realism. This model is an experimental merge of several other models (MythoMix, Mythologic-L2, and Huggin).",
-        "author": {
-            "name": "Gryphe Padar",
-            "url": "https://huggingface.co/Gryphe",
-            "blurb": "Author behind various Mytho merges, most prominent being MythoMax, MythoLogic, and MythoBoros"
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/Gryphe/MythoMax-L2-13b",
-            "downloadUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "mythomax-l2-13b.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "mythomax-l2-13b.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "mythomax-l2-13b.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 7365545088,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "7b71bd39663bfde58c374319e61dbf446fefcd68393f175a628fba8d0361aec7",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/MythoMax-L2-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
-                },
-                {
-                    "name": "mythomax-l2-13b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10678850688,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "37a1ea28a3a08721d2956a8bb87a06127c6036742267174b79d9c7b83133dba0",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/MythoMax-L2-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-07-22T02:20:14.000Z",
-        "name": "Nous-Hermes-Llama2-13b",
-        "description": "The Nous-Hermes-Llama2-13b is a state-of-the-art language model developed by Nous Research in collaboration with Teknium, Emozilla, and Redmond AI, fine-tuned on over 300,000 instructions. It uses the same dataset as its predecessor, Hermes on Llama-1, to maintain consistency while enhancing capability. This model is known for generating long responses with a lower hallucination rate, free from OpenAI censorship mechanisms. It was fine-tuned using a sequence length of 4096 on an 8x a100 80GB DGX machine. The training dataset is composed of synthetic GPT-4 outputs, including data from diverse sources such as GPTeacher, roleplay v1&2, code instruct datasets, and unpublished Nous Instruct & PDACTL, among others. The model utilizes the Alpaca prompt format for instructions and responses.",
-        "author": {
-            "name": "Nous Research",
-            "url": "https://nousresearch.com",
-            "blurb": "Nous Research is dedicated to advancing the field of natural language processing, in collaboration with the open-source community, through bleeding-edge research and a commitment to symbiotic development."
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/NousResearch/Nous-Hermes-Llama2-13b",
-            "downloadUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "nous-hermes-llama2-13b.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q3_K_S.bin",
-                    "sizeBytes": 5874151072,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "9e76993f3e8a804b3ee012bc461fbd01e9ff71fbdf8ac9f6f13ccadd5ff51b4e",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
-                },
-                {
-                    "name": "nous-hermes-llama2-13b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10830311072,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "02f696d0df53174cf9a3aba62d22a1b17882389a5381e68b2c7395845f87d3f5",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/Nous-Hermes-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML"
-                }
-            ]
-        }
-    },
-    {
-        "_descriptorVersion": "0.0.1",
-        "datePublished": "2023-08-11T20:24:21",
-        "name": "OpenOrca-Platypus2-13B",
-        "description": "OpenOrca-Platypus2-13B is a powerful language model developed by merging garage-bAInd/Platypus2-13B and Open-Orca/OpenOrcaxOpenChat-Preview2-13B. It's an auto-regressive model based on the Lllama 2 transformer architecture, trained predominantly in English. The model was tested via Language Model Evaluation Harness and performed impressively on the HuggingFace Leaderboard with an average score of 64.56 across various shot scenarios. It also exceeded the base Preview2 model's performance on AGIEval and BigBench-Hard evaluations. Cole Hunter & Ariel Lee trained Platypus2-13B using the STEM and logic-based dataset garage-bAInd/Open-Platypus, while Open-Orca trained the OpenOrcaxOpenChat-Preview2-13B model using a refined subset of the GPT-4 data from the OpenOrca dataset. The training licenses for the base weights differ, with Platypus2-13B operating under a Non-Commercial Creative Commons license (CC BY-NC-4.0) and OpenOrcaxOpenChat-Preview2-13B under a Llama 2 Commercial license. Detailed training procedures and benchmark results are available in the Platypus GitHub repo.",
-        "author": {
-            "name": "Open Orca",
-            "url": "https://huggingface.co/Open-Orca",
-            "blurb": "A collaboration between Alignment Lab AI and the Platypus / garage-bAInd team"
-        },
-        "numParameters": "13B",
-        "resources": {
-            "canonicalUrl": "https://huggingface.co/Open-Orca/OpenOrca-Platypus2-13B",
-            "downloadUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML",
-            "paperUrl": "https://arxiv.org/abs/2308.07317"
-        },
-        "trainedFor": "chat",
-        "arch": "llama",
-        "files": {
-            "highlighted": {
-                "economical": {
-                    "name": "openorca-platypus2-13b.ggmlv3.q4_K_S.bin"
-                },
-                "most_capable": {
-                    "name": "openorca-platypus2-13b.ggmlv3.q6_K.bin"
-                }
-            },
-            "all": [
-                {
-                    "name": "openorca-platypus2-13b.ggmlv3.q4_K_S.bin",
-                    "url": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML/resolve/main/openorca-platypus2-13b.ggmlv3.q4_K_S.bin",
-                    "sizeBytes": 7558851360,
-                    "quantization": "Q4_K_S",
-                    "format": "ggml",
-                    "sha256checksum": "55318c58c22c4e4a8dd5504919cefde5f843e848b6c96cd06a3ad69f2f41365b",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/OpenOrca-Platypus2-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML"
-                },
-                {
-                    "name": "openorca-platypus2-13b.ggmlv3.q6_K.bin",
-                    "url": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML/resolve/main/openorca-platypus2-13b.ggmlv3.q6_K.bin",
-                    "sizeBytes": 10829916960,
-                    "quantization": "Q6_K",
-                    "format": "ggml",
-                    "sha256checksum": "0487eb1a91683020cb8dc59b096b9f7e086735efdf1cf5f5ec84c842ec0a6799",
-                    "publisher": {
-                        "name": "TheBloke",
-                        "socialUrl": "https://twitter.com/TheBlokeAI"
-                    },
-                    "respository": "TheBloke/OpenOrca-Platypus2-13B-GGML",
-                    "repositoryUrl": "https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML"
+                    "respository": "TheBloke/zephyr-7B-beta-GGUF",
+                    "repositoryUrl": "https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF"
                 }
             ]
         }

--- a/models/falcon-40b-instruct.json
+++ b/models/falcon-40b-instruct.json
@@ -1,0 +1,86 @@
+{
+  "_descriptorVersion": "0.0.1",  
+  "datePublished": "2023-10-22T03:04:42",
+  "name": "falcon-40b-instruct",
+  "description": "Falcon-40B-Instruct, based on Falcon-40B, has been fine-tuned on chat and instruct datasets. It offers outstanding performance and is an excellent choice for chat and instruct applications. Falcon-7B-Instruct is part of the Falcon family of language models, known for their exceptional capabilities and openness.",
+  "author": {
+    "name": "Maddes8cht",
+    "url": "https://huggingface.co/maddes8cht",
+    "blurb": "Maddes8cht Passionate about Open Source and AI. On Hugging Face he is advocating for real open source AI models with OSI compliant licenses"
+  },
+  "numParameters": "40B",
+  "resources": {
+    "canonicalUrl": "https://huggingface.co/tiiuae/falcon-40b-instruct",
+    "downloadUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+  },
+  "trainedFor": "chat",
+  "arch": "falcon",
+  "files": {
+    "highlighted": {
+      "economical": {
+        "name": "tiiuae-falcon-40b-Q4_K_M.gguf"
+      },
+      "most_capable": {
+        "name": "tiiuae-falcon-40b-Q6_K.gguf"
+      }
+    },
+    "all": [
+      {
+        "name": "tiiuae-falcon-40b-instruct-Q2_K.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q2_K.gguf",
+        "sizeBytes": 17400024800,
+        "quantization": "Q2_K",
+        "format": "gguf",
+        "sha256checksum": "93551752b87a1b265c43dbbf3b1cdf47d4ff4d92122fa44ea12e3b0c6f7d1981",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-40b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-40b-instruct-Q4_K_M.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q4_K_M.gguf",
+        "sizeBytes": 25452629728,
+        "quantization": "Q4_K_M",
+        "format": "gguf",
+        "sha256checksum": "ff140febf094721f656568250eb6f288ac8dfa49b5b4483139078761a9515cbb",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-40b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-40b-instruct-Q5_K_M.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf/blob/main/tiiuae-falcon-40b-instruct-Q5_K_M.gguf",
+        "sizeBytes": 30642294496,
+        "quantization": "Q5_K_M",
+        "format": "gguf",
+        "sha256checksum": "fe39d1fc51d35039da996e3d2ed262617d1a70b3d9d0a7762571c749103cba39",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-40b-instruct-Q6_K.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q6_K.gguf",
+        "sizeBytes": 34456456928,
+        "quantization": "Q6_K",
+        "format": "gguf",
+        "sha256checksum": "5c2a9c95dfcb72d34acb09ac304625847a1f3de307984f559e71f7414345a4e9",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-40b-instruct-gguf"
+      }
+    ]
+  }
+}

--- a/models/falcon-7b-instruct.json
+++ b/models/falcon-7b-instruct.json
@@ -1,0 +1,86 @@
+{
+  "_descriptorVersion": "0.0.1",  
+  "datePublished": "2023-10-31T16:01:50",
+  "name": "falcon-7b-instruct",
+  "description": "Falcon-7B-Instruct, based on Falcon-7B, has been fine-tuned on chat and instruct datasets. It offers outstanding performance and is an excellent choice for chat and instruct applications. Falcon-7B-Instruct is part of the Falcon family of language models, known for their exceptional capabilities and openness.",
+  "author": {
+    "name": "Maddes8cht",
+    "url": "https://huggingface.co/maddes8cht",
+    "blurb": "Maddes8cht Passionate about Open Source and AI. On Hugging Face he is advocating for real open source AI models with OSI compliant licenses"
+  },
+  "numParameters": "7B",
+  "resources": {
+    "canonicalUrl": "https://huggingface.co/tiiuae/falcon-7b-instruct",
+    "downloadUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+  },
+  "trainedFor": "chat",
+  "arch": "falcon",
+  "files": {
+    "highlighted": {
+      "economical": {
+        "name": "tiiuae-falcon-7b-instruct-Q4_K_M"
+      },
+      "most_capable": {
+        "name": "tiiuae-falcon-7b-Q6_K.gguf"
+      }
+    },
+    "all": [
+      {
+        "name": "tiiuae-falcon-7b-instruct-Q2_K.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q2_K.gguf",
+        "sizeBytes": 4025162688,
+        "quantization": "Q2_K",
+        "format": "gguf",
+        "sha256checksum": "c0e87b27def08c0a9dc8fa9bfd70cd7bc373d328943530984165ac4b20d2202c",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-7b-instruct-Q4_K_M.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q4_K_M.gguf",
+        "sizeBytes": 4975385792,
+        "quantization": "Q4_K_M",
+        "format": "gguf",
+        "sha256checksum": "6f6c886ed07d4f6133a4dd7f8b799764ed719c50973d96816b2ac5ff3ada9913",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-7b-instruct-Q5_K_M.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q5_K_M.gguf",
+        "sizeBytes": 5731380160,
+        "quantization": "Q5_K_M",
+        "format": "gguf",
+        "sha256checksum": "3a4666a200024584f667b4dcf2761463046924f9b0708ba13315831416d8548a",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+      },
+      {
+        "name": "tiiuae-falcon-7b-instruct-Q6_K.gguf",
+        "url": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf/blob/main/tiiuae-falcon-7b-instruct-Q6_K.gguf",
+        "sizeBytes": 7031618496,
+        "quantization": "Q6_K",
+        "format": "gguf",
+        "sha256checksum": "e6b23eb4193b2d8c7effb4870d2db7a3faa6ed2c8f2c075f7ced51591938818a",
+        "publisher": {
+          "name": "maddes8cht",
+          "socialUrl": "https://twitter.com/maddes1966"
+        },
+        "respository": "maddes8cht/tiiuae-falcon-7b-instruct-gguf",
+        "repositoryUrl": "https://huggingface.co/maddes8cht/tiiuae-falcon-7b-instruct-gguf"
+      }
+    ]
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -51,7 +51,7 @@
       },
       "numParameters": {
         "type": "string",
-        "enum": ["3B", "7B", "13B", "15B", "30B", "65B", "unknown"]
+        "enum": ["3B", "7B", "13B", "15B", "30B", "40B", "65B", "unknown"]
       },
       "trainedFor": {
         "type": "string",
@@ -118,7 +118,7 @@
         },
         "quantization": {
           "type": "string",
-          "enum": ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "Q2_K", "Q3_K_S", "Q3_K_M", "Q4_K_S", "Q4_K_M", "Q5_K_S", "Q5_K_M", "Q6_K", "unknown"]
+          "enum": ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "Q2_K", "Q3_K_S", "Q3_K_M", "Q3_K_L", "Q4_K_S", "Q4_K_M", "Q5_K_S", "Q5_K_M", "Q6_K", "unknown"]
         },
         "format": {
           "type": "string"


### PR DESCRIPTION
Add the major Falcon Moddels, 7b instruct and 40b instruct..
Change schema.json to reflect falcon 40B models:

In schema.json there is one quantization type missing in
definition - ModelFile-properties: There is a `Q3_K_L` type, i added it to the enum.

The apache-licensed Falcon Models come in the flavours of 7B and 40B. 
A 40B option is  missing in the enumeration
`numParameters`, so i added "40B" to the enum.


I have a bunch of other interesting and powerful Falcon-based Models, notably the wizardLM uncensored versions, that i would like to ad to this list.
I will do so if you accept these changes.
