### PR TITLE
Add SeaLLM-7B-v2

### DIFF
--- a/models/SeaLLM-7B-v2.json
+++ b/models/SeaLLM-7B-v2.json
@@ -1,0 +1,14 @@
+{
+    "name": "SeaLLM",
+    "inference_params": {
+      "input_prefix": "</s><|im_start|>user\n",
+      "input_suffix": "</s><|im_start|>assistant\n",
+      "antiprompt": [
+        "<|im_start|>",
+        "</s>"
+      ],
+      "pre_prompt_prefix": "<|im_start|>system\n",
+      "pre_prompt_suffix": "",
+      "pre_prompt": "You are a helpful assistant."
+    }
+  }


### PR DESCRIPTION
SeaLLM-7B-v2 is the latest state-of-the-art multilingual LLM for Southeast Asian (SEA) languages 🇬🇧 🇨🇳 🇻🇳 🇮🇩 🇹🇭 🇲🇾 🇰🇭 🇱🇦 🇲🇲 🇵🇭. It is the most significant upgrade since SeaLLM-13B, with half the size, outperforming performance across diverse multilingual tasks, from world knowledge, math reasoning, instruction following, etc.